### PR TITLE
 Move bind app-keys logic from AppGroup to AppList

### DIFF
--- a/src/appGroup.js
+++ b/src/appGroup.js
@@ -139,6 +139,7 @@ AppGroup.prototype = {
   _onDragEnd: function () {
     this.rightClickMenu.close(false)
     this.hoverMenu.close(false)
+    this.appList._fixAppGroupIndexAfterDrag(this);
     this._applet._clearDragPlaceholder()
   },
 

--- a/src/appGroup.js
+++ b/src/appGroup.js
@@ -303,17 +303,6 @@ AppGroup.prototype = {
     } 
   },
 
-  _newAppKeyNumber: function (number) {
-    if (this.hotKeyId) {
-      Main.keybindingManager.removeHotKey(this.hotKeyId)
-    }
-    if (number < 10) {
-      Main.keybindingManager.addHotKey('launch-app-key-' + number.toString(), '<Super>' + number.toString(), Lang.bind(this, this._onAppKeyPress))
-      Main.keybindingManager.addHotKey('launch-new-app-key-' + number.toString(), '<Super><Shift>' + number.toString(), Lang.bind(this, this._onNewAppKeyPress))
-      this.hotKeyId = 'launch-app-key-' + number.toString()
-    }
-  },
-
   _onAppKeyPress: function () {
     if (this.isFavapp) {
       this.app.open_new_window(-1)

--- a/src/appList.js
+++ b/src/appList.js
@@ -236,7 +236,6 @@ AppList.prototype = {
 
       appGroup._updateMetaWindows(this.metaWorkspace, app, window)
       appGroup.watchWorkspace(this.metaWorkspace)
-      appGroup.isFavapp = isFavapp
 
       this.appList[refApp].appGroup = appGroup
       this.appList[refApp].time = time

--- a/src/appList.js
+++ b/src/appList.js
@@ -371,7 +371,25 @@ AppList.prototype = {
     }
     return result
   },
-
+  
+  _fixAppGroupIndexAfterDrag: function (appGroup) {
+    let originPos = _.findIndex(this.appList, {appGroup: appGroup});
+    var pos = _.findIndex(this.manager_container.get_children(), appGroup.actor);
+    if (originPos === pos
+            || originPos < 0
+            || pos < 0) {
+      return;
+    }
+    if (pos > originPos) {
+      // TBD: if drag to a right position, exclude postion hold by origin
+      pos -= 1;
+    }
+    // originPos -> pos
+    let data = this.appList[originPos];
+    _.pullAt(this.appList, originPos);
+    this.appList.splice(pos, 0, data);
+  },
+  
   _windowRemoved: function (metaWorkspace, metaWindow, app=null) {
     
     // When a window is closed, we need to check if the app it belongs


### PR DESCRIPTION
Keep it simple, bind app-keys in AppList is more controllable than in AppList.

And, two fixes:
+ drag-drop will break binding of app-keys, even origin logic.
+ after drag, AppGroup.isFavapp will become to `true`, new window will be created when click or press app-keys

wish you like this